### PR TITLE
feat: thêm API lấy 10 từ vựng mới nhất

### DIFF
--- a/src/controllers/vocabulary.controller.js
+++ b/src/controllers/vocabulary.controller.js
@@ -107,6 +107,15 @@ const VocabularyController = {
         return await VocabularyService.addVocabulary(req.body)
       },
       'Thêm từ vựng (không có lesson) thành công'
+    ),
+
+  getLatestVocabularies: (req, res) =>
+    handleRequest(
+      res,
+      async () => {
+        return await VocabularyService.fetchLatestVocabularies(10)
+      },
+      'Lấy danh sách từ vựng mới nhất thành công'
     )
 }
 

--- a/src/routes/vocabulary.route.js
+++ b/src/routes/vocabulary.route.js
@@ -17,6 +17,8 @@ router.get(
   VocabularyController.getAllVocabulariesAI
 )
 
+router.get('/latest', VocabularyController.getLatestVocabularies);
+
 router.get(
   '/lesson/:lesson_id',
   authorizeRole(['student', 'teacher', 'admin']),

--- a/src/services/vocabulary.service.js
+++ b/src/services/vocabulary.service.js
@@ -1,5 +1,6 @@
 const LessonRepo = require('../models/repos/lesson.repo')
 const VocabularyRepo = require('../models/repos/vocabulary.repo')
+const vocabularyModel = require('../models/vocabulary.model')
 const throwError = require('../res/throwError')
 const { convert2ObjectId, JapaneseToUnicode } = require('../utils')
 
@@ -149,6 +150,13 @@ const VocabularyService = {
     if (!newVocab) throwError('Vocabulary creation failed')
 
     return newVocab
+  },
+
+  fetchLatestVocabularies: async (limit = 10) => {
+    return vocabularyModel.find()
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .exec();
   }
 }
 


### PR DESCRIPTION
# Thêm API lấy 10 từ vựng mới nhất

## Mục đích

Tạo API mới cho phép client lấy danh sách 10 từ vựng được thêm mới nhất trong hệ thống.  
Giúp ứng dụng dễ dàng hiển thị mục "Từ vựng mới nhất" cho người học.

## Thay đổi chính

- Thêm route GET `/api/vocabularies/latest` trong `vocabulary.js`.
- Thêm controller `getLatestVocabularies` gọi service lấy 10 từ mới nhất.
- Tách logic truy vấn vào service `fetchLatestVocabularies` trong `vocabularyService.js`.
- Sửa model `Vocabulary` nếu cần để có trường `createdAt` (dùng timestamps).

## Cách kiểm thử

1. Khởi động server backend.
2. Gửi GET request tới `http://localhost:3000/api/vocabularies/latest`.
3. Đảm bảo nhận về JSON chứa danh sách 10 từ vựng gần đây nhất, status 200.
4. Kiểm tra trường dữ liệu đúng định dạng, không lỗi.

## Ghi chú

- Cần chạy migrate hoặc cập nhật database nếu model thay đổi.
- API trả về dữ liệu mẫu, chưa có phân trang nâng cao (có thể bổ sung sau).
- Đảm bảo bảo mật endpoint nếu cần trong tương lai.

---

Mong nhận được review và góp ý từ team, cảm ơn mọi người!
